### PR TITLE
Create dev.yml for docker compose

### DIFF
--- a/compose/dev.yml
+++ b/compose/dev.yml
@@ -1,0 +1,7 @@
+version: '3.4'
+services:
+  disco-registry:
+    image: open-disco-newman
+    ports:
+      - "8282:8282"
+    command: []


### PR DESCRIPTION
This file adds a basic dev.yml to allow use of bin/dc up instead of requiring docker-compose up